### PR TITLE
disconnect の時にunlockしてくれない不具合を修正

### DIFF
--- a/lib/bindings/locking_bind.js
+++ b/lib/bindings/locking_bind.js
@@ -20,7 +20,7 @@ function lockingBind (pool, options = {}) {
   return function bindLock (socket) {
     /**
      * Execute locking
-     * @param {string} name 
+     * @param {string} name
      * @param {string} by
      */
     function doLock (name, by) {
@@ -71,7 +71,7 @@ function lockingBind (pool, options = {}) {
     socket.on(DISCONNECT, () => {
       for (let name of Object.keys(pool)) {
         let { by } = pool[ name ]
-        if (by === socket.id) {
+        if (by === socket.client.id) {
           doUnlock(name, by)
         }
       }


### PR DESCRIPTION
サーバー側で受け取った socket オブジェクトで、
socket.id は「名前空間付きのid」になるようなので
socket.client.id にして名前空間なしのidにしました。
